### PR TITLE
fix: fix fibonnaci

### DIFF
--- a/handler/calculate.go
+++ b/handler/calculate.go
@@ -60,7 +60,7 @@ func calculateFibonacciWithTimeout(ctx context.Context, count int) (*big.Int, er
 	resultCh := make(chan *big.Int)
 	go func() {
 		result := utils.Fibbonacci(count)
-		resultCh <- result[count-1]
+		resultCh <- result
 	}()
 	select {
 	case <-ctx.Done():

--- a/utils/calculate.go
+++ b/utils/calculate.go
@@ -2,18 +2,17 @@ package utils
 
 import "math/big"
 
-func Fibbonacci(n int) []*big.Int {
+func Fibbonacci(n int) *big.Int {
 	if n <= 0 {
 		return nil
 	} else if n == 1 {
-		return []*big.Int{big.NewInt(1)}
+		return big.NewInt(1)
 	}
 
-	fib := make([]*big.Int, n)
-	fib[0] = big.NewInt(1)
-	fib[1] = big.NewInt(1)
+	prev := big.NewInt(1)
+	current := big.NewInt(1)
 	for i := 2; i < n; i++ {
-		fib[i] = new(big.Int).Add(fib[i-1], fib[i-2])
+		current, prev = new(big.Int).Add(current, prev), current
 	}
-	return fib
+	return current
 }

--- a/utils/calculate_test.go
+++ b/utils/calculate_test.go
@@ -26,15 +26,15 @@ func TestFibbonacci(t *testing.T) {
 		{
 			name: "Test Fibbonacci 25",
 			args: args{n: 99},
-			want: func() *big.Int{
-				bI, _ := new(big.Int).SetString("218922995834555169026",10)
+			want: func() *big.Int {
+				bI, _ := new(big.Int).SetString("218922995834555169026", 10)
 				return bI
 			}(),
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, Fibbonacci(tt.args.n)[tt.args.n-1])
+			assert.Equal(t, tt.want, Fibbonacci(tt.args.n))
 		})
 	}
 }


### PR DESCRIPTION
昨日眠すぎて頭が働いてない状態で作業していたのでfibonacciの修正を行う際初めて扱うbig.Intはなぜか再代入不可能だと思っていた。全然そんな事なかったのでスライスではなく普通に*big.Intの値を二つ用意して使い回す方式に変えた。

というかそもそも昨日の時点で関数としてfibonacciの結果を返すという振る舞いをするならば[]*big.Intではなく*big.Intを返り値にするべきだった。